### PR TITLE
feat: Post, PostImage 도메인 생성

### DIFF
--- a/aboutTime-application/build.gradle
+++ b/aboutTime-application/build.gradle
@@ -12,4 +12,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/aboutTime-application/build.gradle
+++ b/aboutTime-application/build.gradle
@@ -15,4 +15,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.9'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.9'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/aboutTime-application/build.gradle
+++ b/aboutTime-application/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }

--- a/aboutTime-application/build.gradle
+++ b/aboutTime-application/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     implementation project(":aboutTime-domain")
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }

--- a/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostDto.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostDto.java
@@ -1,0 +1,43 @@
+package com.aboutTime.dto.post;
+
+import com.aboutTime.entity.User;
+import com.aboutTime.entity.post.Post;
+import com.aboutTime.entity.post.PostImage;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class PostDto {
+    private Long postId;
+    private Long authorId;
+
+    private List<PostImageDto> postImages;
+
+    public static PostDto from(Post post) {
+        var postImages = post.getPostImages().stream()
+                .map(PostImageDto::from)
+                .toList();
+
+        return PostDto.builder()
+                .postId(post.getId())
+                .authorId(post.getAuthor().getId())
+                .postImages(postImages)
+                .build();
+    }
+
+    public Post toEntity(User author) {
+        return Post.builder()
+                .author(author)
+                .build();
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostImageDto.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostImageDto.java
@@ -1,0 +1,34 @@
+package com.aboutTime.dto.post;
+
+import com.aboutTime.entity.post.Post;
+import com.aboutTime.entity.post.PostImage;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class PostImageDto {
+
+    private Long postImageId;
+    private String url;
+    private String comment;
+
+    public static PostImageDto from(PostImage postImage) {
+        return PostImageDto.builder()
+                .postImageId(postImage.getId())
+                .url(postImage.getUrl())
+                .comment(postImage.getComment())
+                .build();
+    }
+
+    public PostImage toEntity(Post post) {
+        return new PostImage(url, comment, post);
+
+    }
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/infra/S3Configuration.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/infra/S3Configuration.java
@@ -1,0 +1,33 @@
+package com.aboutTime.infra;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Configuration {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/infra/S3Service.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/infra/S3Service.java
@@ -1,0 +1,60 @@
+package com.aboutTime.infra;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private static final String SEPARATOR = "/";
+    private static final String SEPARATOR_CODE = "%2F";
+    private static final String HTTPS_URI_PREFIX = "https://";
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile file) {
+        var fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        try {
+            var objectMetadata = getObjectMetadataFromFile(file);
+            var inputStream = file.getInputStream();
+            amazonS3.putObject(bucket, fileName, inputStream, objectMetadata);
+        } catch(IOException e) {
+            throw new IllegalStateException("Invalid File", e);
+        } catch (AmazonS3Exception e) {
+            throw new IllegalStateException("Failed to upload file to S3", e);
+        }
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    public void remove(String fileUri) {
+        var fileNameStartIndex = fileUri.indexOf(SEPARATOR, HTTPS_URI_PREFIX.length() + 1);
+        var fileName = fileUri.substring(fileNameStartIndex + 1).replace(SEPARATOR_CODE, SEPARATOR);
+
+        try {
+            amazonS3.deleteObject(bucket, fileName);
+        } catch (AmazonS3Exception e) {
+            throw new IllegalStateException("Failed to remove file from S3", e);
+        }
+    }
+
+    private ObjectMetadata getObjectMetadataFromFile(final MultipartFile imageFile) {
+        var objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(imageFile.getContentType());
+        objectMetadata.setContentLength(imageFile.getSize());
+        return objectMetadata;
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/service/post/PostImageService.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/service/post/PostImageService.java
@@ -1,0 +1,40 @@
+package com.aboutTime.service.post;
+
+import com.aboutTime.common.exception.ResourceNotFoundException;
+import com.aboutTime.entity.post.PostImage;
+import com.aboutTime.entity.post.PostImageRepository;
+import com.aboutTime.entity.post.PostRepository;
+import com.aboutTime.infra.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class PostImageService {
+
+    private final S3Service s3Service;
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+
+    public String uploadImage(Long postId, MultipartFile file, String comment) {
+        var post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + postId));
+
+        var imageUri = s3Service.upload(file);
+        var postImage = new PostImage(imageUri, comment, post);
+        postImageRepository.save(postImage);
+
+        return imageUri;
+    }
+
+
+    public void deleteImage(Long postImageId) {
+        var postImage = postImageRepository.findById(postImageId)
+                .orElseThrow(() -> new ResourceNotFoundException("PostImage not found with id: " + postImageId));
+
+        s3Service.remove(postImage.getUrl());
+        postImageRepository.delete(postImage);
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
@@ -1,0 +1,51 @@
+package com.aboutTime.service.post;
+
+import com.aboutTime.entity.post.Post;
+import com.aboutTime.entity.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    // 모든 Post 리스트 조회
+    public List<Post> getAllPost() {
+        return postRepository.findAll();
+    }
+
+    // UserId에 따른 Post 리스트 조회
+    public List<Post> getAllPostByUserId(Long userId) {
+        return postRepository.findAllByUserId(userId);
+    }
+
+    // post_id에 따른 Post 단건 조회
+    public Post getOnePostById(Long id) {
+        return postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 post가 없습니다."));
+    }
+
+    // Post 저장
+    @Transactional
+    public void save(Post post) {
+        postRepository.save(post);
+    }
+
+    // Post 수정
+
+
+    // Post 삭제
+    @Transactional
+    public void delete(Long id) {
+        var post = postRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 post가 없습니다."));
+        postRepository.delete(post);
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
@@ -1,6 +1,8 @@
 package com.aboutTime.service.post;
 
-import com.aboutTime.entity.post.Post;
+import com.aboutTime.common.exception.ResourceNotFoundException;
+import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.entity.User;
 import com.aboutTime.entity.post.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,36 +17,34 @@ public class PostService {
 
     private final PostRepository postRepository;
 
-    // 모든 Post 리스트 조회
-    public List<Post> getAllPost() {
-        return postRepository.findAll();
+    public List<PostDto> getAllPostByUserId(User user) {
+        return postRepository.findAllByAuthorId((user.getId())).stream()
+                .map(PostDto::from)
+                .toList();
     }
 
-    // UserId에 따른 Post 리스트 조회
-    public List<Post> getAllPostByUserId(Long userId) {
-        return postRepository.findAllByUserId(userId);
+    public PostDto getOnePostById(Long postId) {
+        var post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 post가 없습니다."));
+
+        return PostDto.from(post);
     }
 
-    // post_id에 따른 Post 단건 조회
-    public Post getOnePostById(Long id) {
-        return postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 post가 없습니다."));
-    }
+//    @Transactional
+//    public void save(PostDto postDto, Long authorId) {
+//        var user = userRepository.findById(authorId)
+//                        .orElseThrow(() -> new ResourceNotFoundException("해당하는 유저가 없습니다."));
+//        var post = postRepository.save(postDto.toEntity(user));
+//
+//        Objects.requireNonNull(postDto.getPostImages()).stream()
+//                .map(archiveImageDto -> archiveImageDto.toEntity(post))
+//                .forEach(post::addImage);
+//    }
 
-    // Post 저장
     @Transactional
-    public void save(Post post) {
-        postRepository.save(post);
-    }
-
-    // Post 수정
-
-
-    // Post 삭제
-    @Transactional
-    public void delete(Long id) {
-        var post = postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 post가 없습니다."));
+    public void delete(Long postId) {
+        var post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 post가 없습니다."));
         postRepository.delete(post);
     }
 

--- a/aboutTime-common/src/main/java/com/aboutTime/common/exception/ResourceNotFoundException.java
+++ b/aboutTime-common/src/main/java/com/aboutTime/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,17 @@
+package com.aboutTime.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    private String message;
+    private String errorCode;
+
+    public ResourceNotFoundException(String message) {
+        this.message = message;
+        this.errorCode = "NOT FOUND RESOURCE";
+    }
+
+    public ResourceNotFoundException(String message, String errorCode) {
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/common/BaseTimeEntity.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/common/BaseTimeEntity.java
@@ -1,0 +1,37 @@
+package com.aboutTime.entity.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    public void softDelete() {
+        this.isDeleted = true;
+    }
+
+    public void softDeleteCancel() {
+        this.isDeleted = false;
+    }
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Emoji.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Emoji.java
@@ -1,0 +1,16 @@
+package com.aboutTime.entity.post;
+
+public enum Emoji {
+
+    EMOJI_1,
+    EMOJI_2,
+    EMOJI_3,
+    EMOJI_4,
+    EMOJI_5,
+    EMOJI_6,
+    EMOJI_7,
+    EMOJI_8,
+    EMOJI_9,
+    EMOJI_10
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
@@ -27,16 +27,16 @@ public class Post extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private final List<PostImage> postImages = new ArrayList<>();
 
     @Builder
-    public Post(Long id, User user) {
+    public Post(Long id, User author) {
         this.id = id;
-        this.user = user;
+        this.author = author;
     }
 
     public void addImage(PostImage postImage) {

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
@@ -1,0 +1,46 @@
+package com.aboutTime.entity.post;
+
+import com.aboutTime.entity.User;
+import com.aboutTime.entity.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "post")
+@SQLDelete(sql = "UPDATE post SET is_deleted = true WHERE post_id=?")
+@SQLRestriction("is_deleted = false")
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private final List<PostImage> postImages = new ArrayList<>();
+
+    @Builder
+    public Post(Long id, User user) {
+        this.id = id;
+        this.user = user;
+    }
+
+    public void addImage(PostImage postImage) {
+        this.postImages.add(postImage);
+    }
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
@@ -33,6 +33,9 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private final List<PostImage> postImages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private final List<Reaction> reactions = new ArrayList<>();
+
     @Builder
     public Post(Long id, User author) {
         this.id = id;

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
@@ -32,9 +32,8 @@ public class PostImage extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @Builder
-    public PostImage(Long id, String comment, Post post) {
-        this.id = id;
+    public PostImage(String url, String comment, Post post) {
+        this.url = url;
         this.comment = comment;
         this.post = post;
     }

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
@@ -1,0 +1,42 @@
+package com.aboutTime.entity.post;
+
+import com.aboutTime.entity.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "post_image")
+@SQLDelete(sql = "UPDATE post_image SET is_deleted = true WHERE post_image_id=?")
+@SQLRestriction("is_deleted = false")
+public class PostImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_image_id")
+    private Long id;
+
+    @Column(name = "image_url")
+    private String url;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public PostImage(Long id, String comment, Post post) {
+        this.id = id;
+        this.comment = comment;
+        this.post = post;
+    }
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImageRepository.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImageRepository.java
@@ -1,0 +1,6 @@
+package com.aboutTime.entity.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostRepository.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostRepository.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByUserId(Long userId);
+    List<Post> findAllByAuthorId(Long authorId);
 
 }

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostRepository.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostRepository.java
@@ -1,0 +1,11 @@
+package com.aboutTime.entity.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByUserId(Long userId);
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Reaction.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Reaction.java
@@ -1,0 +1,47 @@
+package com.aboutTime.entity.post;
+
+import com.aboutTime.entity.User;
+import com.aboutTime.entity.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "post")
+@SQLDelete(sql = "UPDATE post SET is_deleted = true WHERE post_id=?")
+@SQLRestriction("is_deleted = false")
+public class Reaction extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reaction_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Emoji emoji;
+
+    @Column(name = "count")
+    private int emojiCount;
+
+    public Reaction(Post post, User user, Emoji emoji) {
+        this.post = post;
+        this.user = user;
+        this.emoji = emoji;
+        this.emojiCount = 0;
+    }
+
+}

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/ReactionRepository.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/ReactionRepository.java
@@ -1,0 +1,6 @@
+package com.aboutTime.entity.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostControllerDocs.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostControllerDocs.java
@@ -1,0 +1,25 @@
+package com.aboutTime.api.docs.swagger;
+
+import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface PostControllerDocs {
+
+    @Operation(summary = "포스트 리스트 조회", description = "특정 사용자의 모든 포스트를 조회합니다.")
+    ResponseEntity<List<PostDto>> postList(User user);
+
+    @Operation(summary = "포스트 상세 조회", description = "포스트 ID를 통해 포스트를 상세 조회합니다.")
+    ResponseEntity<PostDto> postSpecificView(@Parameter(name="id", description = "조회할 포스트의 ID") Long id);
+
+//    @Operation(summary = "포스트 생성")
+//    ResponseEntity<Object> savePost(PostDto postDto, User user);
+
+    @Operation(summary = "포스트 삭제")
+    void deletePost(@Parameter(name="id", description = "삭제할 포스트의 ID") Long id);
+
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostImageControllerDocs.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostImageControllerDocs.java
@@ -1,0 +1,20 @@
+package com.aboutTime.api.docs.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+
+public interface PostImageControllerDocs {
+
+    @Operation(summary = "이미지 업로드")
+    ResponseEntity<String> uploadImage(
+            @Parameter(name = "image") MultipartFile file,
+            @Parameter(name = "id", description = "포스트 아이디") Long potId,
+            @Parameter(name = "comment", description = "사지 설명") String comment);
+
+    @Operation(summary = "이미지 삭제")
+    ResponseEntity<Void> removeImage(Long postImageId);
+
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/exception/ExceptionController.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/exception/ExceptionController.java
@@ -1,0 +1,17 @@
+package com.aboutTime.api.exception;
+
+import com.aboutTime.common.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ExceptionController {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundException(ResourceNotFoundException e) {
+        var response = new ExceptionResponse("Resource Not Found Exception", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/exception/ExceptionResponse.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/exception/ExceptionResponse.java
@@ -1,0 +1,18 @@
+package com.aboutTime.api.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExceptionResponse {
+
+    private String message;
+    private String code;
+
+    public ExceptionResponse(String message, String code) {
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/post/PostController.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/post/PostController.java
@@ -1,0 +1,41 @@
+package com.aboutTime.api.post;
+
+import com.aboutTime.api.docs.swagger.PostControllerDocs;
+import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.entity.User;
+import com.aboutTime.service.post.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class PostController implements PostControllerDocs {
+
+    private final PostService postService;
+
+    @GetMapping
+    public ResponseEntity<List<PostDto>> postList(User user) {
+        return ResponseEntity.ok(postService.getAllPostByUserId(user));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PostDto> postSpecificView(@PathVariable Long id) {
+        return ResponseEntity.ok(postService.getOnePostById(id));
+    }
+
+//    @PostMapping
+//    public ResponseEntity<Object> savePost(@RequestBody PostDto postDto, User user) {
+//        postService.save(postDto, user.getId());
+//        return ResponseEntity.status(HttpStatus.CREATED).build();
+//    }
+
+    @DeleteMapping("/{id}")
+    public void deletePost(@PathVariable Long id) {
+        postService.delete(id);
+    }
+}

--- a/aboutTime-web/src/main/java/com/aboutTime/api/post/PostImageController.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/post/PostImageController.java
@@ -1,0 +1,34 @@
+package com.aboutTime.api.post;
+
+import com.aboutTime.api.docs.swagger.PostImageControllerDocs;
+import com.aboutTime.service.post.PostImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/post")
+@RequiredArgsConstructor
+public class PostImageController implements PostImageControllerDocs {
+
+    private final PostImageService imageService;
+
+    @PostMapping(path = "/image/upload",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> uploadImage(@RequestParam("image") MultipartFile file,
+                                                 @RequestParam("id") Long postId,
+                                                 @RequestParam(value = "comment", required = false) String comment) {
+        var imageUri = imageService.uploadImage(postId, file, comment);
+        return ResponseEntity.ok(imageUri);
+    }
+
+    @DeleteMapping("/image/remove")
+    public ResponseEntity<Void> removeImage(Long postImageId) {
+        imageService.deleteImage(postImageId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/aboutTime-web/src/main/resources/application-local.yml
+++ b/aboutTime-web/src/main/resources/application-local.yml
@@ -7,3 +7,15 @@ spring:
     url: ${DEV_DB_URL}
     username: ${DEV_DB_USERNAME}
     password: ${DEV_DB_PASSWORD}
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+    region:
+      static: ${REGION_STATIC}
+    stack:
+      auto: false
+    credentials:
+      instance-profile: true
+      accessKey: ${AWS_ACCESSKEY}
+      secretKey: ${AWS_SECRETKEY}


### PR DESCRIPTION
> **Post, PostImage 기본 Entity 세팅**

## To-Do
- [ ] `Post` 도메인
   - [x] 필드 추가 - `user`, `postImage`
   - [x] 리액션 정보(이모지) 추가
   - [ ] 날씨, 공개범위 추가
   - [x] 테이블 생성
- [x] `PostImage` 도메인
   - [x] 필드 추가 - `post`, `url`, `comment`
   - [x] Amazon S3 config 추가
   - [x] 테이블 생성
- [x] `Reaction` 도메인
   - [x] `Emoji` enum 생성
   - [x] 테이블 생성

