### PR TITLE
feat: post 조회 및 생성 API 구현

### DIFF
--- a/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostDto.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostDto.java
@@ -3,13 +3,16 @@ package com.aboutTime.dto.post;
 import com.aboutTime.entity.User;
 import com.aboutTime.entity.post.Post;
 import com.aboutTime.entity.post.PostImage;
+import com.aboutTime.entity.post.Reaction;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -17,27 +20,48 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 public class PostDto {
+
     private Long postId;
+    private LocalDateTime createdAt;
+    private String mainImage;
+    private String mainComment;
     private Long authorId;
 
     private List<PostImageDto> postImages;
+//    private List<Reaction> reactions;
 
-    public static PostDto from(Post post) {
-        var postImages = post.getPostImages().stream()
-                .map(PostImageDto::from)
-                .toList();
-
-        return PostDto.builder()
-                .postId(post.getId())
-                .authorId(post.getAuthor().getId())
-                .postImages(postImages)
+    public Post toEntity(Long authorId) {
+        return Post.builder()
+                .mainImage(mainImage)
+                .mainComment(mainComment)
+                .authorId(authorId)
                 .build();
     }
 
-    public Post toEntity(User author) {
-        return Post.builder()
-                .author(author)
-                .build();
+    public static PostDto specificForm(Post post) {
+        List<PostImageDto> images = post.getPostImages().stream()
+                .map(PostImageDto::from)
+                .collect(Collectors.toList());
+
+        return new PostDto(
+                post.getId(),
+                post.getCreatedAt(),
+                post.getMainImage(),
+                post.getMainComment(),
+                post.getAuthorId(),
+                images
+        );
+    }
+
+    public static PostDto simpleForm(Post post) {
+        return new PostDto(
+                post.getId(),
+                post.getCreatedAt(),
+                post.getMainImage(),
+                post.getMainComment(),
+                post.getAuthorId(),
+                null
+        );
     }
 
 }

--- a/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostSaveRequestDto.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/dto/post/PostSaveRequestDto.java
@@ -1,0 +1,31 @@
+package com.aboutTime.dto.post;
+
+import com.aboutTime.entity.post.Post;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class PostSaveRequestDto {
+
+    private String mainImage;
+    private String mainComment;
+    private List<PostImageDto> postImages;
+
+    public Post toEntity(Long authorId) {
+        return Post.builder()
+                .mainImage(mainImage)
+                .mainComment(mainComment)
+                .authorId(authorId)
+                .build();
+    }
+
+}

--- a/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
+++ b/aboutTime-application/src/main/java/com/aboutTime/service/post/PostService.java
@@ -2,6 +2,7 @@ package com.aboutTime.service.post;
 
 import com.aboutTime.common.exception.ResourceNotFoundException;
 import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.dto.post.PostSaveRequestDto;
 import com.aboutTime.entity.User;
 import com.aboutTime.entity.post.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -17,9 +19,18 @@ public class PostService {
 
     private final PostRepository postRepository;
 
-    public List<PostDto> getAllPostByUserId(User user) {
-        return postRepository.findAllByAuthorId((user.getId())).stream()
-                .map(PostDto::from)
+    public List<PostDto> getAllPostByUserId(Long userId) {
+//        return postRepository.findAllByAuthorId((user.getId())).stream()
+//                .map(PostDto::from)
+//                .toList();
+        return postRepository.findAllByAuthorId(userId).stream()
+                .map(PostDto::simpleForm)
+                .toList();
+    }
+
+    public List<PostDto> getAllPost() {
+        return postRepository.findAll().stream()
+                .map(PostDto::simpleForm)
                 .toList();
     }
 
@@ -27,19 +38,19 @@ public class PostService {
         var post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 post가 없습니다."));
 
-        return PostDto.from(post);
+        return PostDto.specificForm(post);
     }
 
-//    @Transactional
-//    public void save(PostDto postDto, Long authorId) {
+    @Transactional
+    public void save(PostSaveRequestDto postRequestDto, Long authorId) {
 //        var user = userRepository.findById(authorId)
 //                        .orElseThrow(() -> new ResourceNotFoundException("해당하는 유저가 없습니다."));
-//        var post = postRepository.save(postDto.toEntity(user));
-//
-//        Objects.requireNonNull(postDto.getPostImages()).stream()
-//                .map(archiveImageDto -> archiveImageDto.toEntity(post))
-//                .forEach(post::addImage);
-//    }
+        var post = postRepository.save(postRequestDto.toEntity(authorId));
+
+        Objects.requireNonNull(postRequestDto.getPostImages()).stream()
+                .map(archiveImageDto -> archiveImageDto.toEntity(post))
+                .forEach(post::addImage);
+    }
 
     @Transactional
     public void delete(Long postId) {

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/Post.java
@@ -1,6 +1,5 @@
 package com.aboutTime.entity.post;
 
-import com.aboutTime.entity.User;
 import com.aboutTime.entity.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -26,9 +25,18 @@ public class Post extends BaseTimeEntity {
     @Column(name = "post_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id", nullable = false)
-    private User author;
+    @Column(name = "main_image")
+    private String mainImage;
+
+    @Column(name = "main_comment")
+    private String mainComment;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "author_id", nullable = false)
+//    private User author;
+    // 테스트를 위해 authorId=1인 유저만 사용
+    @Column(name = "author_id")
+    private Long authorId;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private final List<PostImage> postImages = new ArrayList<>();
@@ -37,13 +45,19 @@ public class Post extends BaseTimeEntity {
     private final List<Reaction> reactions = new ArrayList<>();
 
     @Builder
-    public Post(Long id, User author) {
+    public Post(Long id, String mainImage, String mainComment, Long authorId) {
         this.id = id;
-        this.author = author;
+        this.mainImage = mainImage;
+        this.mainComment = mainComment;
+        this.authorId = authorId;
     }
 
     public void addImage(PostImage postImage) {
         this.postImages.add(postImage);
     }
+
+//    public void addReaction(Reaction reaction) {
+//        this.reactions.add(reaction);
+//    }
 
 }

--- a/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
+++ b/aboutTime-domain/src/main/java/com/aboutTime/entity/post/PostImage.java
@@ -3,7 +3,6 @@ package com.aboutTime.entity.post;
 import com.aboutTime.entity.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;

--- a/aboutTime-web/src/main/java/com/aboutTime/AboutTimeWebApplication.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/AboutTimeWebApplication.java
@@ -2,7 +2,9 @@ package com.aboutTime;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = "com.aboutTime")
 public class AboutTimeWebApplication {
     public static void main(String[] args) {

--- a/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostControllerDocs.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostControllerDocs.java
@@ -1,6 +1,7 @@
 package com.aboutTime.api.docs.swagger;
 
 import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.dto.post.PostSaveRequestDto;
 import com.aboutTime.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,15 +12,15 @@ import java.util.List;
 public interface PostControllerDocs {
 
     @Operation(summary = "포스트 리스트 조회", description = "특정 사용자의 모든 포스트를 조회합니다.")
-    ResponseEntity<List<PostDto>> postList(User user);
+    ResponseEntity<List<PostDto>> postList(@Parameter(name = "userId") Long userId);
 
     @Operation(summary = "포스트 상세 조회", description = "포스트 ID를 통해 포스트를 상세 조회합니다.")
-    ResponseEntity<PostDto> postSpecificView(@Parameter(name="id", description = "조회할 포스트의 ID") Long id);
+    ResponseEntity<PostDto> postSpecificView(@Parameter(name = "postId", description = "조회할 포스트의 ID") Long postId);
 
-//    @Operation(summary = "포스트 생성")
-//    ResponseEntity<Object> savePost(PostDto postDto, User user);
+    @Operation(summary = "포스트 생성")
+    ResponseEntity<Object> savePost(@Parameter PostSaveRequestDto requestDto, @Parameter(name = "authorId") Long authorId);
 
     @Operation(summary = "포스트 삭제")
-    void deletePost(@Parameter(name="id", description = "삭제할 포스트의 ID") Long id);
+    void deletePost(@Parameter(name = "id", description = "삭제할 포스트의 ID") Long id);
 
 }

--- a/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostImageControllerDocs.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/docs/swagger/PostImageControllerDocs.java
@@ -15,6 +15,6 @@ public interface PostImageControllerDocs {
             @Parameter(name = "comment", description = "사지 설명") String comment);
 
     @Operation(summary = "이미지 삭제")
-    ResponseEntity<Void> removeImage(Long postImageId);
+    ResponseEntity<Void> removeImage(@Parameter(name = "postImageId") Long postImageId);
 
 }

--- a/aboutTime-web/src/main/java/com/aboutTime/api/post/PostController.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/post/PostController.java
@@ -2,6 +2,7 @@ package com.aboutTime.api.post;
 
 import com.aboutTime.api.docs.swagger.PostControllerDocs;
 import com.aboutTime.dto.post.PostDto;
+import com.aboutTime.dto.post.PostSaveRequestDto;
 import com.aboutTime.entity.User;
 import com.aboutTime.service.post.PostService;
 import lombok.RequiredArgsConstructor;
@@ -19,20 +20,25 @@ public class PostController implements PostControllerDocs {
     private final PostService postService;
 
     @GetMapping
-    public ResponseEntity<List<PostDto>> postList(User user) {
-        return ResponseEntity.ok(postService.getAllPostByUserId(user));
+    public ResponseEntity<List<PostDto>> postList(@RequestParam("userId") Long userId) {
+        return ResponseEntity.ok(postService.getAllPostByUserId(userId));
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<PostDto> postSpecificView(@PathVariable Long id) {
-        return ResponseEntity.ok(postService.getOnePostById(id));
+    @GetMapping("/all")
+    public ResponseEntity<List<PostDto>> getAllPost() {
+        return ResponseEntity.ok(postService.getAllPost());
     }
 
-//    @PostMapping
-//    public ResponseEntity<Object> savePost(@RequestBody PostDto postDto, User user) {
-//        postService.save(postDto, user.getId());
-//        return ResponseEntity.status(HttpStatus.CREATED).build();
-//    }
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDto> postSpecificView(@PathVariable("postId") Long postId) {
+        return ResponseEntity.ok(postService.getOnePostById(postId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Object> savePost(@RequestBody PostSaveRequestDto requestDto, @RequestParam("authorId") Long authorId) {
+        postService.save(requestDto, authorId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 
     @DeleteMapping("/{id}")
     public void deletePost(@PathVariable Long id) {

--- a/aboutTime-web/src/main/java/com/aboutTime/api/post/PostImageController.java
+++ b/aboutTime-web/src/main/java/com/aboutTime/api/post/PostImageController.java
@@ -26,7 +26,7 @@ public class PostImageController implements PostImageControllerDocs {
     }
 
     @DeleteMapping("/image/remove")
-    public ResponseEntity<Void> removeImage(Long postImageId) {
+    public ResponseEntity<Void> removeImage(@RequestParam("postImageId") Long postImageId) {
         imageService.deleteImage(postImageId);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
- post 리스트 조회 및 생성, 삭제 기능 구현
- 추후 필드 추가 예정 - 날씨 정보, 리액션, 공개 범위 등
- 아직 `user` 정보를 조회할 수 없어서 `userId`를 직접 사용하는 방식으로 구현 (추후 수정 예정)